### PR TITLE
Fix/token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # GappEssentials CHANGELOG
 
+## 2.4.0
+### Bugfixes
+- Fix session token decryption in API header handling
+### Other
+- Update copyright year to 2026
+- Bump minimum GLPI version to 10.0.25
+
 ## 2.3.0
 ### Features
 - Endpoint get item documents

--- a/apirest.php
+++ b/apirest.php
@@ -2,7 +2,7 @@
 /*
  -------------------------------------------------------------------------
  GappEssentials plugin for GLPI
- Copyright (C) 2019 by the TICgal
+ Copyright (C) 2026 by the TICGAL
  https://tic.gal
  https://github.com/pluginsGLPI/gappessentials
  -------------------------------------------------------------------------

--- a/front/config.form.php
+++ b/front/config.form.php
@@ -2,7 +2,7 @@
 /*
  -------------------------------------------------------------------------
  GappEssentials plugin for GLPI
- Copyright (C) 2019 by the TICgal
+ Copyright (C) 2026 by the TICGAL
  https://tic.gal
  https://github.com/pluginsGLPI/gappessentials
  -------------------------------------------------------------------------

--- a/hook.php
+++ b/hook.php
@@ -2,7 +2,7 @@
 /*
  -------------------------------------------------------------------------
  GappEssentials plugin for GLPI
- Copyright (C) 2019 by the TICgal
+ Copyright (C) 2026 by the TICGAL
  https://tic.gal
  https://github.com/pluginsGLPI/gappessentials
  -------------------------------------------------------------------------

--- a/inc/apirest.class.php
+++ b/inc/apirest.class.php
@@ -193,7 +193,7 @@ class PluginGappEssentialsApirest extends Glpi\Api\API
 
 		// try to retrieve session_token in header
 		if (isset($headers['Session-Token'])) {
-			$parameters['session_token'] = $headers['Session-Token'];
+			$parameters['session_token'] = (new GLPIKey())->decrypt(\base64_decode(trim($headers['Session-Token'])));
 		}
 
 		// try to retrieve app_token in header

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2,7 +2,7 @@
 /*
  -------------------------------------------------------------------------
  GappEssentials plugin for GLPI
- Copyright (C) 2019 by the TICgal
+ Copyright (C) 2026 by the TICGAL
  https://tic.gal
  https://github.com/pluginsGLPI/gappessentials
  -------------------------------------------------------------------------

--- a/setup.php
+++ b/setup.php
@@ -28,9 +28,9 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_GAPPESSENTIALS_VERSION', '2.3.0');
+define('PLUGIN_GAPPESSENTIALS_VERSION', '2.4.0-beta');
 // Minimal GLPI version, inclusive
-define("PLUGIN_GAPPESSENTIALS_MIN_GLPI", "10.0.3");
+define("PLUGIN_GAPPESSENTIALS_MIN_GLPI", "10.0.25");
 define("PLUGIN_GAPPESSENTIALS_MAX_GLPI", "10.0.99");
 
 /**

--- a/setup.php
+++ b/setup.php
@@ -2,7 +2,7 @@
 /*
  -------------------------------------------------------------------------
  GappEssentials plugin for GLPI
- Copyright (C) 2019 by the TICgal
+ Copyright (C) 2026 by the TICGAL
  https://tic.gal
  https://github.com/pluginsGLPI/gappessentials
  -------------------------------------------------------------------------
@@ -28,7 +28,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_GAPPESSENTIALS_VERSION', '2.4.0-beta');
+define('PLUGIN_GAPPESSENTIALS_VERSION', '2.4.0');
 // Minimal GLPI version, inclusive
 define("PLUGIN_GAPPESSENTIALS_MIN_GLPI", "10.0.25");
 define("PLUGIN_GAPPESSENTIALS_MAX_GLPI", "10.0.99");


### PR DESCRIPTION
## 2.4.0
### Bugfixes
- Fix session token decryption in API header handling
### Other
- Update copyright year to 2026
- Bump minimum GLPI version to 10.0.25