### PR TITLE
fix: session token decryption in API header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GappEssentials CHANGELOG
 
+## 3.1.0
+### Bugfixes
+- Fix session token decryption in API header handling
+
 ## 3.0.0
 ### Features
 - GLPI 11 Compatibility

--- a/inc/apirest.class.php
+++ b/inc/apirest.class.php
@@ -29,6 +29,8 @@
  * -------------------------------------------------------------------------
 */
 
+use Safe\Exceptions\UrlException;
+
 class PluginGappEssentialsApirest extends Glpi\Api\API
 {
 	protected $request_uri;
@@ -216,7 +218,12 @@ class PluginGappEssentialsApirest extends Glpi\Api\API
 
         // try to retrieve session_token in header
         if (isset($headers['Session-Token'])) {
-            $parameters['session_token'] = $headers['Session-Token'];
+            try {
+                $parameters['session_token'] = (new GLPIKey())->decrypt(base64_decode(trim($headers['Session-Token'])));
+            } catch (UrlException) {
+                // malformed session token, keep its raw value and let authentication code fail due to mismatch token
+                $parameters['session_token'] = $headers['Session-Token'];
+            }
         }
 
         // try to retrieve app_token in header

--- a/setup.php
+++ b/setup.php
@@ -36,9 +36,9 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_GAPPESSENTIALS_VERSION', '3.0.0');
+define('PLUGIN_GAPPESSENTIALS_VERSION', '3.1.0-beta');
 // Minimal GLPI version, inclusive
-define("PLUGIN_GAPPESSENTIALS_MIN_GLPI", "11.0.0");
+define("PLUGIN_GAPPESSENTIALS_MIN_GLPI", "11.0.7");
 define("PLUGIN_GAPPESSENTIALS_MAX_GLPI", "11.0.99");
 define("PLUGIN_GAPPESSENTIALS_ICON", "fa-solid fa-e");
 

--- a/setup.php
+++ b/setup.php
@@ -36,7 +36,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_GAPPESSENTIALS_VERSION', '3.1.0-beta');
+define('PLUGIN_GAPPESSENTIALS_VERSION', '3.1.0');
 // Minimal GLPI version, inclusive
 define("PLUGIN_GAPPESSENTIALS_MIN_GLPI", "11.0.7");
 define("PLUGIN_GAPPESSENTIALS_MAX_GLPI", "11.0.99");


### PR DESCRIPTION
## Summary
- Decrypt the `Session-Token` header value using `GLPIKey` before passing it to the authentication layer
- Handle malformed/unencoded tokens gracefully — if decryption fails, fall back to the raw value so authentication fails cleanly instead of crashing
- Bump version to 3.1.0