### PR TITLE
Update gappessentials.xml

### DIFF
--- a/gappessentials.xml
+++ b/gappessentials.xml
@@ -31,6 +31,11 @@
    </authors>
    <versions>
       <version>
+         <num>3.2.0</num>
+         <compatibility>^11.0.7</compatibility>
+         <download_url>https://github.com/ticgal/gappessentials/releases/download/3.2.0/glpi-gappessentials-3.2.0.tar.bz2</download_url>
+      </version>
+      <version>
          <num>3.1.0</num>
          <compatibility>^11.0.7</compatibility>
          <download_url>https://github.com/ticgal/gappessentials/releases/download/3.1.0/glpi-gappessentials-3.1.0.tar.bz2</download_url>
@@ -44,6 +49,11 @@
          <num>3.0.0-beta4</num>
          <compatibility>~11.0.0</compatibility>
          <download_url>https://github.com/ticgal/gappessentials/releases/download/3.0.0-beta/glpi-gappessentials-3.0.0-beta4.tar.bz2</download_url>
+      </version>
+      <version>
+         <num>2.5.0</num>
+         <compatibility>^10.0.25</compatibility>
+         <download_url>https://github.com/ticgal/gappessentials/releases/download/2.5.0/glpi-gappessentials-2.5.0.tar.bz2</download_url>
       </version>
       <version>
          <num>2.4.0</num>


### PR DESCRIPTION
feat: add Gapp Essentials v3.2.0 (GLPI 11) and v2.5.0 (GLPI 10) to marketplace manifest